### PR TITLE
remove data attribute to both class arraymapper and rowmapper. Its us…

### DIFF
--- a/src/Mappers/ArrayMapper.php
+++ b/src/Mappers/ArrayMapper.php
@@ -28,11 +28,6 @@ class ArrayMapper implements DataSourceInterface
     /**
      * @var array
      */
-    private $data = [];
-
-    /**
-     * @var array
-     */
     private $params;
 
     /**
@@ -54,17 +49,13 @@ class ArrayMapper implements DataSourceInterface
      */
     public function getData()
     {
-        if (!empty($this->data)) {
-            return $this->data;
-        }
-
+        $data = [];
         foreach ($this->dataSource->getData() as $row) {
-            $this->data[] = array_map(function (PickerInterface $picker) use ($row) {
+            $data [] = array_map(function (PickerInterface $picker) use ($row) {
                 return $picker->pick(new Row($row));
             }, $this->matchers);
         }
-
-        return $this->data;
+        return $data;
     }
 
     /**

--- a/src/Mappers/RowMapper.php
+++ b/src/Mappers/RowMapper.php
@@ -27,11 +27,6 @@ class RowMapper implements RowInterface
     /**
      * @var array
      */
-    private $data;
-
-    /**
-     * @var array
-     */
     private $params;
 
     /**
@@ -52,15 +47,9 @@ class RowMapper implements RowInterface
      */
     public function getRow()
     {
-        if (!empty($this->data)) {
-            return $this->data;
-        }
-
-        $this->data = array_map(function(PickerInterface $picker) {
+        return array_map(function(PickerInterface $picker) {
             return $picker->pick($this->row);
         }, $this->matchers);
-
-        return $this->data;
     }
 
     /**


### PR DESCRIPTION
Removing "data" attribute to both class arraymapper and rowmapper. Its useless now, and the pseudo-cache handling had introduced a bug when instance is called multiple times, the data wasn't reloaded if params where different. We need to use a real cache management if we want to have good performances without any issue.
