### PR TITLE
Modifying ArrayMapper behavior

### DIFF
--- a/src/Mappers/ArrayMapper.php
+++ b/src/Mappers/ArrayMapper.php
@@ -51,9 +51,12 @@ class ArrayMapper implements DataSourceInterface
     {
         $data = [];
         foreach ($this->dataSource->getData() as $row) {
-            $data [] = array_map(function (PickerInterface $picker) use ($row) {
-                return $picker->pick(new Row($row));
-            }, $this->matchers);
+            foreach ($this->matchers as $picker){
+                if (!($return = $picker->pick(new Row($row)))) {
+                    continue;
+                }
+                $data [] = $return;
+            }
         }
         return $data;
     }


### PR DESCRIPTION
We replaced the array_map() process with a foreach, to continue the iteration if the pick of a PickerInterface is returning false. This allows to only have the wanted final values in the returning array of the getData() method instead of, for example, have null values or false values in this array.
